### PR TITLE
Laurel readme edits for simple-rds

### DIFF
--- a/terraform/rds-simple/README.md
+++ b/terraform/rds-simple/README.md
@@ -7,12 +7,18 @@ and assigns it a custom parameters group with modified parameters.
 ## Getting started
 1. Make sure that the database engine you want to provision is enabled in Symphony.
 
+   To enable an engine, from the Symphony GUI, click
+   
+   **Menu** > **Database** > **Engines** > *click an engine name* > **Enabled**
+
 2. Make sure you have the latest version of Terraform installed.
 
 3. Set these values in the `terraform.tfvars` file:
    
    `symphony_ip`: The IP of your Symphony region
    
-   `access_key` and `secret_key`: To get these values, start the Symphony GUI. In the upper right corner of the GUI, click **Hi username** > **Access Keys**.
+   `access_key` and `secret_key`: To get these values, start the Symphony GUI.
+   
+   In the upper right corner of the GUI, click **Hi username** > **Access Keys**.
    
 4. Run `terraform apply`.

--- a/terraform/rds-simple/README.md
+++ b/terraform/rds-simple/README.md
@@ -1,6 +1,5 @@
 # RDS Simple Example
-This example creates an RDS instance using Terraform. It creates an instance,  
-and assigns it a custom parameters group with modified parameters.
+This example creates an RDS instance using Terraform.
 
 > Note: This example provisions a MySQL 5.7 version.
 
@@ -17,8 +16,6 @@ and assigns it a custom parameters group with modified parameters.
    
    `symphony_ip`: The IP of your Symphony region
    
-   `access_key` and `secret_key`: To get these values, start the Symphony GUI.
-   
-   In the upper right corner of the GUI, click **Hi username** > **Access Keys**.
+   `access_key` and `secret_key`: To get these values, start the Symphony GUI. In the upper right corner of the GUI, click **Hi username** > **Access Keys**.
    
 4. Run `terraform apply`.

--- a/terraform/rds-simple/README.md
+++ b/terraform/rds-simple/README.md
@@ -1,11 +1,18 @@
 # RDS Simple Example
-This example demonstrates creating an RDS instance using terraform, it will create an instance  
-and assign it with a custom parameters group with modified parameters.
+This example creates an RDS instance using Terraform. It creates an instance,  
+and assigns it a custom parameters group with modified parameters.
 
-> Note: This example will provision a MySQL 5.7 version
+> Note: This example provisions a MySQL 5.7 version.
 
 ## Getting started
-1. Make sure you have the database engine you want to provision is enabled in Symphony.
-2. Make sure you have the latest terraform installed
-3. Modify the `terraform.tfvars` file according to your environment variables
-4. Run `terraform apply`
+1. Make sure that the database engine you want to provision is enabled in Symphony.
+
+2. Make sure you have the latest version of Terraform installed.
+
+3. Set these values in the `terraform.tfvars` file:
+   
+   `symphony_ip`: The IP of your Symphony region
+   
+   `access_key` and `secret_key`: To get these values, start the Symphony GUI. In the upper right corner of the GUI, click **Hi username** > **Access Keys**.
+   
+4. Run `terraform apply`.

--- a/terraform/rds-simple/aws-provider.tf
+++ b/terraform/rds-simple/aws-provider.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 
     endpoints {
-        ec2 = "https://${var.symphony_ip}/api/v2/ec2"
+        ec2 = "https://${var.symphony_ip}/api/v2/aws/ec2"
         rds = "https://${var.symphony_ip}/api/v2/aws/rds"
     }
 

--- a/terraform/wordpress/database.tf
+++ b/terraform/wordpress/database.tf
@@ -1,0 +1,28 @@
+# Create db instance 
+
+
+#make db subnet group 
+resource "aws_db_subnet_group" "dbsubnet" {
+  name       = "main"
+  subnet_ids = ["${aws_subnet.db_subnet.id}"]
+}
+
+#provision the database
+resource "aws_db_instance" "wpdb" {
+  identifier = "wpdb"
+  instance_class = "db.m1.medium"
+  allocated_storage = 50
+  engine = "mysql"
+  name = "${var.db_name}"
+  password = "${var.db_password}"
+  username = "${var.db_user}"
+  engine_version = "5.7.00"
+  skip_final_snapshot = true
+  db_subnet_group_name = "${aws_db_subnet_group.dbsubnet.name}"
+  # to get around a bug in 4.2.5 (fixed in newer revision)
+  lifecycle {
+    ignore_changes = ["engine", "auto_minor_version_upgrade"]
+  }
+}
+
+#TODO: Add SG's 

--- a/terraform/wordpress/loadbalancer.tf
+++ b/terraform/wordpress/loadbalancer.tf
@@ -1,0 +1,76 @@
+
+#Provision load balancer
+resource "aws_alb" "alb" {
+  subnets = ["${aws_subnet.pub_subnet.id}"]
+  internal = false
+  security_groups = ["${aws_security_group.lb-sec.id}"]
+  #depends_on = ["aws_route_table_association.rtb_assoc_to_pub"]
+
+  #workaround
+  lifecycle {
+    ignore_changes = ["load_balancer_type", "security_groups"]
+  }
+}
+
+resource "aws_alb_target_group" "targ" {
+  port = 8080
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.app_vpc.id}"
+
+  #workaround - won't be needed in 4.2.6
+  lifecycle {
+    ignore_changes = ["port", "target_type", "vpc_id"]
+  }
+}
+
+resource "aws_alb_target_group_attachment" "attach_web1" {
+  target_group_arn = "${aws_alb_target_group.targ.arn}"
+  target_id = "${aws_instance.web-server1.id}"
+  port = 8080
+}
+
+resource "aws_alb_target_group_attachment" "attach_web2" {
+  target_group_arn = "${aws_alb_target_group.targ.arn}"
+  target_id = "${aws_instance.web-server2.id}"
+  port = 8080
+}
+
+resource "aws_alb_listener" "list" {
+  "default_action" {
+    target_group_arn = "${aws_alb_target_group.targ.arn}"
+    type = "forward"
+  }
+  load_balancer_arn = "${aws_alb.alb.arn}"
+  port = 80
+//  depends_on = ["aws_instance.web-server"]
+}
+
+resource "aws_security_group" "lb-sec" {
+  name = "lb-secgroup"
+  vpc_id = "${aws_vpc.app_vpc.id}"
+
+  # HTTP access from anywhere
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  # HTTPS access from anywhere
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  #ping from anywhere
+    ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # default security group has egress completely free
+}

--- a/terraform/wordpress/network.tf
+++ b/terraform/wordpress/network.tf
@@ -1,0 +1,61 @@
+#Provision vpc, subnets, igw, and default route
+#1 VPC - 3 subnets (public, web, database)
+
+#provision app vpc
+resource "aws_vpc" "app_vpc" {
+  cidr_block = "192.168.0.0/16"
+  assign_generated_ipv6_cidr_block = false
+  enable_dns_support = false
+  enable_dns_hostnames = false
+  tags {
+    Name = "WP Solution VPC"
+  }
+}
+
+#create igw
+resource "aws_internet_gateway" "app_igw" {
+  vpc_id = "${aws_vpc.app_vpc.id}"
+}
+
+#provision public subnet 
+resource "aws_subnet" "pub_subnet"{
+  vpc_id = "${aws_vpc.app_vpc.id}"
+  cidr_block = "192.168.10.0/24"
+  tags {
+      Name = "public subnet"
+  }
+}
+
+#provision webserver subnet
+resource "aws_subnet" "web_subnet" {
+  vpc_id = "${aws_vpc.app_vpc.id}"
+  cidr_block = "192.168.20.0/24"
+  tags {
+    Name = "web server subnet"
+  }
+}
+
+#provision database subnet
+resource "aws_subnet" "db_subnet" {
+  vpc_id = "${aws_vpc.app_vpc.id}"
+  cidr_block = "192.168.30.0/24"
+  tags {
+    # name didn't apply - file a bug
+    Name = "database subnet"
+  }
+}
+
+ #new default route table 
+ # having issues deploying in Symphony
+resource "aws_default_route_table" "default" {
+   default_route_table_id = "${aws_vpc.app_vpc.default_route_table_id}"
+
+   route {
+       cidr_block = "0.0.0.0/0"
+       gateway_id = "${aws_internet_gateway.app_igw.id}"
+   }
+}
+
+
+
+

--- a/terraform/wordpress/provider.tf
+++ b/terraform/wordpress/provider.tf
@@ -1,0 +1,20 @@
+#Define API Endpoints for Symphony
+
+provider "aws" {
+  access_key = "${var.symp_access_key}"
+  secret_key = "${var.symp_secret_key}"
+
+  endpoints {
+    ec2 = "https://${var.symphony_ip}/api/v2/aws/ec2"
+    elb = "https://${var.symphony_ip}/api/v2/aws/elb"
+    rds = "https://${var.symphony_ip}/api/v2/aws/rds"
+  }
+
+  insecure = "true"
+  skip_metadata_api_check = true
+  skip_credentials_validation = true
+
+  # No importance for this value currently
+  region = "us-east-2"
+//  version = "<=1.15"
+}

--- a/terraform/wordpress/readme.md
+++ b/terraform/wordpress/readme.md
@@ -1,0 +1,31 @@
+Wordpress deployment with RDS, and ELB
+
+-Deploy containerizer WordPress image over Xenial cloud image
+-Reference external RDS instance
+-Deploy ELB for wp instances
+
+Networks to be provisioned:
+- 1 VPC 
+- 2 Database subnets 
+- 1  Web subnets 
+- 2  public subnets 
+
+Resources:
+
+1 ELB
+2 web servers (or more) (Ubuntu Xenial with docker container running WordPress)
+1 RDS instance (MySql)
+
+Stratoscale Symphony Requirements:
+-Load balancing enabled and initialized from the UI
+-RDS Enabled with Mysql 5.7 engine initialized
+-VPC mode enabled for tenant project
+    -Afterwards create a security group (call it open_sg) and find it's UUID via aws cli
+        -1 egress rule: any traffic out from anywhere
+
+
+Tested with: Terraform v0.11.7
+
+Known issues:
+-Issue with security groups (needs to be manually specified in variable open_sg)
+-2nd VM not deploying (count bug?)

--- a/terraform/wordpress/variables.tf
+++ b/terraform/wordpress/variables.tf
@@ -1,0 +1,13 @@
+variable "symp_secret_key" {}
+variable "symp_access_key" {}
+variable "symphony_ip" {}
+variable "web_number" {}
+variable "web_ami" {}
+variable "web_instance_type" {}
+
+variable "db_password" {}
+variable "db_user" {}
+variable "db_name" {}
+
+#variable "open_sg" {}
+

--- a/terraform/wordpress/web.tf
+++ b/terraform/wordpress/web.tf
@@ -1,0 +1,102 @@
+#Deploy Wordpress instances
+
+#Reference to bash script which prepares xenial image
+data "template_file" "wpdeploy"{
+  template = "${file("./webconfig.conf")}"
+
+  vars {
+    db_ip = "${aws_db_instance.wpdb.address}"
+    db_user = "${var.db_user}"
+    db_password = "${var.db_password}"
+  }
+}
+
+resource "aws_instance" "web-server1" {
+  ami = "${var.web_ami}"
+  # The public SG is added for SSH and ICMP
+  vpc_security_group_ids = ["${aws_security_group.pub.id}", "${aws_security_group.web-sec.id}", "${aws_security_group.allout.id}"]
+  instance_type = "${var.web_instance_type}"
+  subnet_id = "${aws_subnet.web_subnet.id}"
+
+  tags {
+    Name = "web-server-1"
+  }
+ # count = "${var.web_number}"
+  user_data = "${data.template_file.wpdeploy.rendered}"
+}
+
+resource "aws_instance" "web-server2" {
+  ami = "${var.web_ami}"
+  # The public SG is added for SSH and ICMP
+  vpc_security_group_ids = ["${aws_security_group.pub.id}", "${aws_security_group.web-sec.id}", "${aws_security_group.allout.id}"]
+  instance_type = "${var.web_instance_type}"
+  subnet_id = "${aws_subnet.web_subnet.id}"
+
+  tags {
+    Name = "web-server-2"
+  }
+ # count = "${var.web_number}"
+  user_data = "${data.template_file.wpdeploy.rendered}"
+}
+
+resource "aws_security_group" "web-sec" {
+  name = "webserver-secgroup"
+  vpc_id = "${aws_vpc.app_vpc.id}"
+
+  # Internal HTTP access from anywhere
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  #ssh from anywhere (unnecessary)
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  # ping access from anywhere
+  ingress {
+    from_port   = 8
+    to_port     = 0
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+
+#public access sg 
+resource "aws_security_group" "pub" {
+  name = "pub-secgroup"
+  vpc_id = "${aws_vpc.app_vpc.id}"
+
+  # ssh access from anywhere
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  # ping access from anywhere
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  # default security group has egress completely free
+}
+
+resource "aws_security_group" "allout" {
+  name = "allout-secgroup"
+  vpc_id = "${aws_vpc.app_vpc.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform/wordpress/webconfig.conf
+++ b/terraform/wordpress/webconfig.conf
@@ -1,0 +1,24 @@
+#cloud-config
+
+# For a Xenial cloud image
+
+# configure dns
+manage_resolv_conf: true
+
+resolv_conf:
+  nameservers: ['8.8.4.4', '8.8.8.8']
+
+
+package_update: true
+
+package_upgrade: true
+
+# install docker
+packages:
+- docker.io
+
+
+# download and start container
+runcmd:
+  - docker pull wordpress
+  - docker run --name wpsite -e WORDPRESS_DB_HOST=${db_ip}:3306 -e WORDPRESS_DB_USER=${db_user} -e WORDPRESS_DB_PASSWORD=${db_password} -p 8080:80 -d wordpress


### PR DESCRIPTION
Hi,

@liaz-stratoscale    

As you know, Anat asked me to start working with and expanding some of the Terraform `readme.md` files, so just starting here as a "test run."

I updated the following files:

`readme.md`

Cleaned up some things, and added some additional info. Plus removed the part that talks about adding a parameter group, because as far as I can tell, `simple-rds.tf` does not do that -- it just creates network entities and a DB instance -- no parameter group. 


`aws-provider.tf`

I changed aws-provider.tf so that it uses the new EC2 endpoint:

/api/v2/aws/ec2/