### PR TITLE
Laurel symp basic setup

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -84,5 +84,7 @@ Tip: If you see a truncated version of the ID that ends in an ellipsis (three do
 
 ## Usage Guidelines
 1. To easily configure an example to work against your environment, modify the `terrafrom.tfvars` file with the proper values.
-2. Make sure you have the latest terraform version deployed
+
+2. Make sure you have the latest Terraform version deployed.
+
 3. For more information, visit terraform documentation at: https://www.terraform.io/docs/providers/aws/index.html

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -82,7 +82,7 @@ ami-1b8ecb82893a4d1f9d500ce33d90496c
 Tip: If you see a truncated version of the ID that ends in an ellipsis (three dots) ... then change the resolution of your screen so that the letters and numbers are very small, and you should be able to see and copy the whole ID.
 
 
-## Usage Guidelines
+## How to Use
 1. To easily configure an example to work against your environment, modify the `terrafrom.tfvars` file with the proper values.
 
 2. Make sure you have the latest Terraform version deployed.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -29,49 +29,49 @@ You also associate this project with a Symphony shared edge network, which becom
 
 1. Within the Symphony GUI, create the project: 
 
-**Menu** > **Account Management** > **Accounts** > select an account > **Create Project**
+    **Menu** > **Account Management** > **Accounts** > select an account > **Create Project**
 
-Specify a name (such as "Terraform" in this example) and optional description for the project.
+    Specify a name (such as "Terraform" in this example) and optional description for the project.
 
 2. Associate an existing user with the Terraform project:
 
-Highlight the Terraform project you just created, then click **Assign Users**: 
+    Highlight the Terraform project you just created, then click **Assign Users**: 
 
-Fill in these fields:
+    Fill in these fields:
 
-User: select a user from the drop down list
+    User: select a user from the drop down list
 
-Project Roles: select Tenant Admin
+    Project Roles: select Tenant Admin
 
 3. Provision a VPC for the Terraform project.
 
-Click the **name** of the project to display the details page, then click **Provision VPC**
+    Click the **name** of the project to display the details page, then click **Provision VPC**
 
-From the Edge Network drop down menu, select a shared edge network.
+    From the Edge Network drop down menu, select a shared edge network.
 
-**Important** 
+    **Important** 
 
-This edge network serves as the default internet gateway for the VPC that you are associating with this project. So, at this point, the VPC associated with the Terraform project you just created contains:
+    This edge network serves as the default internet gateway for the VPC that you are associating with this project. So, at this point, the VPC associated with the Terraform project you just created contains:
 
-* A default internet gateway
+    * A default internet gateway
 
-* A default subnet
+    * A default subnet
 
-* A default route table
+    * A default route table
 
 4. Next, you need to create credentials (access and secret key) for accessing this VPC from Terraform. Note that each project has its own access/secret keys. This means that when you pass in these keys to Terraform, you are telling Terraform what Symphony VPC/project to access.
 
-To create access keys for the Terraform project:
+    **To create access keys for the Terraform project:**
 
-Click Hi *user_name* > Access Keys > Create
+    Click **Hi *user_name* > Access Keys > Create**
 
-The system displays the Access and Secret keys. To copy each key to the clipboard, click the clipboard icon to the right of the key. 
+    The system displays the Access and Secret keys. To copy each key to the clipboard, click the clipboard icon to the right of the key. 
 
 ### Get the AWS ID for an image
 
 Whenever you want to use Terraform to create an instance in Symphony, you need to pass in the AMI ID of the image. This ID needs to be in AWS ID format.
 
-To get the AWS ID from Symphony:
+**To get the AWS ID from Symphony:**
 
 From within the GUI, click **Menu** > **Applications** > **Images**
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,7 +3,7 @@ Examples of using the Terraform AWS provider against Stratoscale Symphony
 
 ## Before You Begin - Symphony Setup
 
-Here are the setup tasks you need to do using the Symphony GUI, before you can run Terraform against Symphony.
+Here are the setup tasks you need to do within the Symphony GUI, before you can run Terraform against Symphony.
 
 ### Create a dedicated VPC-enabled project for Terraform
 
@@ -35,7 +35,7 @@ Specify a name (such as "Terraform" in this example) and optional description fo
 
 2. Associate an existing user with the Terraform project:
 
-Highlight the Terraform project you just created > **Assign Users**: 
+Highlight the Terraform project you just created, then click **Assign Users**: 
 
 Fill in these fields:
 
@@ -45,7 +45,7 @@ Project Roles: select Tenant Admin
 
 3. Provision a VPC for the Terraform project.
 
-Click the **name** of the project to display the details page > **Provision VPC**
+Click the **name** of the project to display the details page, then click **Provision VPC**
 
 From the Edge Network drop down menu, select a shared edge network.
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,5 +1,84 @@
 # Symphony Terraform Examples
-Examples of using Terraform AWS provider against Stratoscale Symphony
+Examples of using the Terraform AWS provider against Stratoscale Symphony
+
+## Before You Begin - Symphony Setup
+
+### Create a dedicated VPC-enabled project for Terraform
+
+Before you can use Terraform against Stratoscale Symphony, you need to create a Symphony project that is dedicated for use only by the AWS API (including Terraform):
+
+* You use this project and its access/secret keys for all Terraform operations.
+
+* You do NOT use this project for any non-AWS Symphony actions.
+
+Benefits:
+
+Once you create this project, you associate it with a VPC. The VPC automatically provides default values for a subnet and routing table. 
+
+You also associate this project with a Symphony shared edge network, which becomes the VPC's default internet gateway.
+
+**Prerequisites for creating the VPC-enabled project**
+
+* You must be a Symphony tenant admin to create the project.
+
+* A shared edge network must already exist in your Symphony region.
+
+**To create a VPC-enabled project for use by Teraform:**
+
+1. Within the Symphony GUI, create the project: 
+
+**Menu** > **Account Management** > **Accounts** > select an account > **Create Project**
+
+Specify a name (such as "Terraform" in this example) and optional description for the project.
+
+2. Associate an existing user with the Terraform project:
+
+Highlight the Terraform project you just created > **Assign Users**: 
+
+Fill in these fields:
+
+User: select a user from the drop down list
+
+Project Roles: select Tenant Admin
+
+3. Provision a VPC for the Terraform project.
+
+Click the **name** of the project to display the details page > **Provision VPC**
+
+From the Edge Network drop down menu, select a shared edge network.
+
+**Important** 
+
+This edge network serves as the default internet gateway for the VPC that you are associating with this project. So, at this point, the VPC associated with the Terraform project you just created contains:
+
+* A default internet gateway
+
+* A default subnet
+
+* A default route table
+
+4. Next, you need to create credentials (access and secret key) for accessing this VPC from Terraform. Note that each project has its own access/secret keys. This means that when you pass in these keys to Terraform, you are telling Terraform what Symphony VPC/project to access.
+
+To create access keys for the Terraform project:
+
+Click Hi *user_name* > Access Keys > Create
+
+The system displays the Access and Secret keys. To copy each key to the clipboard, click the clipboard icon to the right of the key. 
+
+### Get the AWS ID for an image
+
+Whenever you want to use Terraform to create an instance in Symphony, you need to pass in the AMI ID of the image.
+
+To get the AWS ID from Symphony:
+
+From within the GUI, click **Menu** > **Applications** > **Images**
+
+Highlight the image whose ID you want and scroll down to the bottom of the page to find the AWS ID value -- it has a format like this:
+
+ami-1b8ecb82893a4d1f9d500ce33d90496c
+
+Tip: If you see a truncated version of the ID that ends in an ellipsis (three dots) ... then change the resolution of your screen so that the letters and numbers are very small, and you should be able to see and copy the whole ID.
+
 
 ## Usage Guidelines
 1. To easily configure an example to work against your environment, modify the `terrafrom.tfvars` file with the proper values.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,6 +3,8 @@ Examples of using the Terraform AWS provider against Stratoscale Symphony
 
 ## Before You Begin - Symphony Setup
 
+Here are the setup tasks you need to do using the Symphony GUI, before you can run Terraform against Symphony.
+
 ### Create a dedicated VPC-enabled project for Terraform
 
 Before you can use Terraform against Stratoscale Symphony, you need to create a Symphony project that is dedicated for use only by the AWS API (including Terraform):

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -69,7 +69,7 @@ The system displays the Access and Secret keys. To copy each key to the clipboar
 
 ### Get the AWS ID for an image
 
-Whenever you want to use Terraform to create an instance in Symphony, you need to pass in the AMI ID of the image.
+Whenever you want to use Terraform to create an instance in Symphony, you need to pass in the AMI ID of the image. This ID needs to be in AWS ID format.
 
 To get the AWS ID from Symphony:
 

--- a/terraform/ec2-instance/README.md
+++ b/terraform/ec2-instance/README.md
@@ -1,10 +1,22 @@
 # Overview - Simple EC2 Instance
-This terraform example creates a very simple ec2 instance from an ami.\n
-To get the ami id, simply fetch the image uuid from the Symphony UI, and convert it to the AWS format:
-`ami-<uuid without dashes>`
+This Terraform example creates a very simple EC2 instance from an AMI stored in Symphony.
 
-## Getting started
-1. Make sure you have the latest terraform installed
-2. Modify the `terraform.tfvars` file according to your environment
-3. Run `terraform apply`
+## Before You Begin - Symphony Setup
+
+Before you can use this Terraform example, you need to do the following tasks within the Symphony GUI:
+
+* Create a dedicated VPC-enabled project for use with Terraform.
+
+* Get the unique access and secret keys for that project.
+
+* Get the ID of the AMI image you will use as the basis for your EC2 instance. This ID must be in AWS ID format.
+
+These taske are described [here](https://github.com/Stratoscale/strato-aws-examples/tree/laurel-symp-basic-setup/terraform#before-you-begin---symphony-setup)
+
+## How to Use
+1. Make sure you have the latest versioin of Terraform installed.
+
+2. Modify the `terraform.tfvars` file according to your environment.
+
+3. Run `terraform apply`.
 


### PR DESCRIPTION
This pull request covers my additions to the following 2 readme.md files:

* The top level readme.md -- this now contains detailed instructions on what you need to do within the Symp GUI before running Terraform. Specifically it covers creating a dedicated, VPC-enabled project, creating access and secret keys for that project, and obtaining and AWS ID for an image you want to use in your Terraform scripts.

* The readme.md for the ec2-instance folder -- this is the readme for the simple "create an EC2 instance and that's all" example. This readme outlines the preliminary Symp GUI steps briefly, but then has a link that points to the top level readme.md for detailed instructions.

ISSUE: This link works fine in my laurel-symp-basic-setup branch. However, it may or may not work once it gets to master. Meaning, maybe I have to do the link differently -- to be determined. If it doesn't work, I may need help on figuring out how to do the link so that it does work from in master.

@liaz-stratoscale 