### PR TITLE
updated for 4.2.7

### DIFF
--- a/terraform/alb-web-servers/README.md
+++ b/terraform/alb-web-servers/README.md
@@ -15,3 +15,4 @@ To get the ami id, simply fetch the image uuid from the Symphony UI, and convert
 2. Create/Specify a security group
 3. Modify the `terraform.tfvars` file according to your environment
 4. Run `terraform apply`
+5. After the solution is deployed, you should be able to go to the IP of your load balancer and refresh, each time it should redirect you to the other web server which is displaying it's instance ID so you know you're on a different server. 

--- a/terraform/alb-web-servers/README.md
+++ b/terraform/alb-web-servers/README.md
@@ -3,7 +3,12 @@ This terraform will create two webservers from a given ami, and instantiate a lo
 To get the ami id, simply fetch the image uuid from the Symphony UI, and convert it to the AWS format:
 `ami-<uuid without dashes>`
 
->This example's load balancer is configured as internal
+>This example's load balancer is configured as external, you can modify it to internal by modifying the alb-web.tf file
+
+## Symphony Pre-requisite Check list
+1. Ensure you have enabled and initialized load balancer service
+2. Ensure you have imported an Ubuntu Xenial cloud image and made this image public, grab the AMI ID and insert it into your .tfvars file
+3. Ensure your tenants project that you are deploying into has VPC mode enabled, with access keys generated (insert the access/secret keys into your .tfvars file)
 
 ## Getting started
 1. Make sure you have the latest terraform installed

--- a/terraform/alb-web-servers/alb-web.tf
+++ b/terraform/alb-web-servers/alb-web.tf
@@ -151,7 +151,7 @@ resource "aws_alb" "alb" {
     subnets = ["${aws_subnet.subnet1.id}"]
     internal = false
     security_groups = ["${aws_security_group.lb-sec.id}"]
-    subnets = ["${aws_subnet.subnet1.id}"]
+    load_balancer_type = "application"
 }
 
 resource "aws_alb_target_group" "targ" {

--- a/terraform/alb-web-servers/alb-web.tf
+++ b/terraform/alb-web-servers/alb-web.tf
@@ -40,7 +40,7 @@ resource "aws_internet_gateway" "app_igw" {
 #new default route table with igw association 
 
 resource "aws_default_route_table" "default" {
-   default_route_table_id = "${aws_vpc.app_vpc.default_route_table_id}"
+   default_route_table_id = "${aws_vpc.default.default_route_table_id}"
 
    route {
        cidr_block = "0.0.0.0/0"

--- a/terraform/alb-web-servers/alb-web.tf
+++ b/terraform/alb-web-servers/alb-web.tf
@@ -1,22 +1,45 @@
+###################################
 # Creating a VPC & Networking
+###################################
+
 resource "aws_vpc" "default" {
     cidr_block = "10.48.0.0/16"
-    enable_dns_support = false
+    enable_dns_support = true
+  tags {
+    Name = "ALB Example VPC"
+  }
 }
 
 resource "aws_subnet" "subnet1"{
     cidr_block = "10.48.1.0/24"
     vpc_id = "${aws_vpc.default.id}"
 }
+
+
+###################################
+# Cloud init data
+
+data "template_cloudinit_config" "web_config" {
+  gzip = false
+  base64_encode = false
+
+  part {
+    filename     = "webconfig.cfg"
+    content_type = "text/cloud-config"
+    content      = "${data.template_file.web.rendered}"
+  }
+}
+
 ###################################
 
-# Creating two instances of web server ami
+# Creating two instances of web server ami with cloudinit
 resource "aws_instance" "web1" {
     ami = "${var.ami_webserver}"
     instance_type = "t2.micro"
     subnet_id = "${aws_subnet.subnet1.id}"
 
-    security_groups = ["${var.sg_web_servers}"]
+    vpc_security_group_ids = ["${aws_security_group.web-sec.id}", "${aws_security_group.allout.id}"]
+    user_data = "${data.template_cloudinit_config.web_config.rendered}"
 }
 
 resource "aws_instance" "web2" {
@@ -24,7 +47,54 @@ resource "aws_instance" "web2" {
     instance_type = "t2.micro"
     subnet_id = "${aws_subnet.subnet1.id}"
 
-    security_groups = ["${var.sg_web_servers}"]
+    vpc_security_group_ids = ["${aws_security_group.web-sec.id}", "${aws_security_group.allout.id}"]
+    user_data = "${data.template_cloudinit_config.web_config.rendered}"
+}
+
+
+##################################
+# Security group definitions
+
+resource "aws_security_group" "web-sec" {
+  name = "webserver-secgroup"
+  vpc_id = "${aws_vpc.app_vpc.id}"
+
+  # Internal HTTP access from anywhere
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  #ssh from anywhere (for debugging)
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  # ping access from anywhere
+  ingress {
+    from_port   = 8
+    to_port     = 0
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+#public access sg 
+
+# allow all egress traffic (needed for server to download packages)
+resource "aws_security_group" "allout" {
+  name = "allout-secgroup"
+  vpc_id = "${aws_vpc.app_vpc.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
 ##################################

--- a/terraform/alb-web-servers/alb-web.tf
+++ b/terraform/alb-web-servers/alb-web.tf
@@ -32,6 +32,24 @@ resource "aws_vpc_dhcp_options_association" "dns_resolver" {
 }
 
 
+# create igw
+resource "aws_internet_gateway" "app_igw" {
+  vpc_id = "${aws_vpc.default.id}"
+}
+
+#new default route table with igw association 
+
+resource "aws_default_route_table" "default" {
+   default_route_table_id = "${aws_vpc.app_vpc.default_route_table_id}"
+
+   route {
+       cidr_block = "0.0.0.0/0"
+       gateway_id = "${aws_internet_gateway.app_igw.id}"
+   }
+}
+
+
+
 ###################################
 # Cloud init data
 

--- a/terraform/alb-web-servers/aws-provider.tf
+++ b/terraform/alb-web-servers/aws-provider.tf
@@ -13,4 +13,5 @@ provider "aws" {
 
     # No importance for this value currently
     region = "us-east-2"
+    version = "1.28"
 }

--- a/terraform/alb-web-servers/terraform.tfvars.sample
+++ b/terraform/alb-web-servers/terraform.tfvars.sample
@@ -1,9 +1,3 @@
-# Region Setting
-symphony_ip = "<Symphony Region>"
-ami_webserver = "<ami>"
-sg_web_servers = "<security group name>"
-
-
 # .tfvars Sample File
 # Remember to omit the .sample from the extension prior to running Terraform
 

--- a/terraform/alb-web-servers/variables.tf
+++ b/terraform/alb-web-servers/variables.tf
@@ -5,4 +5,3 @@ variable "access_key" {}
 
 # Main variables
 variable "ami_webserver" {}
-variable "sg_web_servers" {}

--- a/terraform/alb-web-servers/webconfig.cfg
+++ b/terraform/alb-web-servers/webconfig.cfg
@@ -1,0 +1,26 @@
+#cloud-config
+
+# Xenial Ubuntu test5
+
+output:
+    init:
+        output: "> /var/log/cloud-init.out"
+        error: "> /var/log/cloud-init.err"
+    config: "tee -a /var/log/cloud-config.log"
+    final:
+        - ">> /var/log/cloud-final.out"
+        - "/var/log/cloud-final.err"
+
+        
+
+package_update: true
+
+package_upgrade: true
+
+packages:
+- docker.io
+
+runcmd:
+  - docker pull httpd
+  - docker run -dit --name my-apache-app -p 8080:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4
+  - docker run --name wpsite -e WORDPRESS_DB_HOST=${db_ip}:3306 -e WORDPRESS_DB_USER=${db_user} -e WORDPRESS_DB_PASSWORD=${db_password} -p 8080:80 -d wordpress

--- a/terraform/alb-web-servers/webconfig.cfg
+++ b/terraform/alb-web-servers/webconfig.cfg
@@ -1,6 +1,6 @@
 #cloud-config
 
-# Xenial Ubuntu test5
+# Xenial Ubuntu 
 
 output:
     init:
@@ -11,7 +11,6 @@ output:
         - ">> /var/log/cloud-final.out"
         - "/var/log/cloud-final.err"
 
-        
 
 package_update: true
 
@@ -22,5 +21,6 @@ packages:
 
 runcmd:
   - docker pull httpd
+  - WEBSRV=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+  - echo Welcome to $WEBSRV > index.html
   - docker run -dit --name my-apache-app -p 8080:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4
-  - docker run --name wpsite -e WORDPRESS_DB_HOST=${db_ip}:3306 -e WORDPRESS_DB_USER=${db_user} -e WORDPRESS_DB_PASSWORD=${db_password} -p 8080:80 -d wordpress

--- a/terraform/wordpress-3tier-app/loadbalancer.tf
+++ b/terraform/wordpress-3tier-app/loadbalancer.tf
@@ -92,10 +92,6 @@ resource "aws_alb_target_group" "targ" {
   port = 8080
   protocol = "HTTP"
   vpc_id = "${aws_vpc.app_vpc.id}"
-
-  #workaround - won't be needed in 4.2.6
-  lifecycle {
-    ignore_changes = ["port", "target_type", "vpc_id"]
   }
 }
 

--- a/terraform/wordpress-3tier-app/web.tf
+++ b/terraform/wordpress-3tier-app/web.tf
@@ -91,7 +91,7 @@ resource "aws_security_group" "web-sec" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  #ssh from anywhere (unnecessary)
+  #ssh from anywhere (for debugging)
   ingress {
     from_port   = 22
     to_port     = 22


### PR DESCRIPTION
alb-web-server example is updated for 4.2.7 and working. Terraform AWS provider is pinned to 1.28. 