### PR TITLE
From Laurel's fork: Wordpress readme edits

### DIFF
--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -43,7 +43,7 @@ Before you can use this Terraform example, you need to do the following tasks wi
 
     **Menu** > **Account Management** > **Accounts** > select an account > **Create Project** > select existing Symphony edge network for this project
 
-    For more information about using VPC-enabled projects, see [additional information about using VPC-enabled projects](https://www.stratoscale.com/docs/using-a-vpc-enabled-project/?preview_id=26391&preview_nonce=aff515ec73&preview=true).
+    For more information about using VPC-enabled projects, see [additional information about using VPC-enabled projects](https://knowledge2.stratoscale.com/display/SYMP/Using+a+VPC-Enabled+Project).
     
 2. Create a **Tenant Admin user** that is associated the the project you just created:
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -1,0 +1,83 @@
+# Wordpress Example
+
+This example shows you how to use Terraform to create a a 3-tier application environment for Wordpress.
+
+## What this example installs:
+
+Networks:
+
+1 VPC
+1 Database subnets
+1 Web subnets
+1 Public subnet
+
+Other resources: 
+
+1 Netwrok Load Balancer
+1 or more web servers (Ubuntu Xenial)
+1 RDS instance (MySQL 5.7)
+1 Floating IP from the Symphony edge network
+
+## Before You Begin
+
+Before you can use this Terraform example, you need to:
+
+* First, do some setup tasks within Symphony.
+
+* Then, create a terraform.tfvars file that supplies your environment-specific values for various variables.
+
+Each task is described below.
+
+
+### Symphony setup tasks
+
+Before you can use this Terraform example, you need to do the following tasks within the Symphony GUI:
+
+1. Create a **dedicated VPC-enabled project** for use with Terraform:
+
+    **Menu** > **Account Management** > **Accounts** > select an account > **Create Project** > select existing Symphony edge network for this project
+
+    For more information about using VPC-enabled projects, see <link-to-public-doc>
+    
+2. Create a **Tenant Admin user** that is associated the the project you just created:
+
+    **Menu** > **Account Management*** > **Accounts** > select an account > "Users" > "Create User"
+    
+    **Projects** field: specify the project you just created
+    
+    **Account Roles** field: specify **Tenant Admin***
+    
+3. Get the **access and secret keys for the project**:
+
+    Log in to the Symhony GUI as the Tenant Admin user you just created.
+    
+    In the upper right corner, click "Hi username" > "Access Keys" > "Create"
+    
+    Copy both the access key and the secret key (click the copy icon to the right of each key).
+    
+
+4. **Upload the image** you will use for your web server(s) into Symphony:
+
+    Use an Ubuntu Xenial cloud image.
+    
+    Handy URL - https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+    
+    To upload the image into Symphony:
+    
+    **Menu** > **Applications** > **Images** > **Create** > specify URL
+    
+    
+5. Get the **AMI ID** for the image you just uploaded into Symphony:
+
+    **Menu** > **Applications** > **Images**
+    
+    Click the name of the image you just uploaded and copy the AWS ID value -- it has a format like this:
+    
+    ami-1b8ecb82893a4d1f9d500ce33d90496c
+    
+    
+### Create `terraform.tfvars`
+
+
+    
+    

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -146,21 +146,21 @@ Database name.
 
 4. Point your browser to Wordpress at this location:
 
-`http://<wordpress_ip>:80`
+    `http://<wordpress_ip>:80`
 
-Initially, you will see the Wordpress installation and configuration pages.
+    Initially, you will see the Wordpress installation and configuration pages.
 
-How to get the _<wordpress_ip>_:
+    How to get the _<wordpress_ip>_:
 
-The Wordpress IP that you want here is the elastiic IP (EIP) of the load balancer:
+    The Wordpress IP that you want here is the elastiic IP (EIP) of the load balancer:
 
-* This load balancer EIP was part of the output from `terraform apply`. You can always redisplay that output by running `terraform refresh`.
+    * This load balancer EIP was part of the output from `terraform apply`. You can always redisplay that output by running `terraform refresh`.
 
-* You can also get the load balancer EIP from the Symphony GUI:
+    * You can also get the load balancer EIP from the Symphony GUI:
 
-**Menu** > **Load Balancing** > **Load Balancers** > select the load that Terraform just created
+    **Menu** > **Load Balancing** > **Load Balancers** > select the load that Terraform just created
 
-The field marked **Floating IP** contains the load balancer EIP that you need to access Wordpress.
+    The field marked **Floating IP** contains the load balancer EIP that you need to access Wordpress.
 
 
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -1,8 +1,8 @@
 # Wordpress Example
 
-This example shows you how to use Terraform to create a a 3-tier application environment for Wordpress.
+This example shows you how to use Terraform to create a 3-tier application environment for Wordpress.
 
-## What this example installs
+## What this example deploys
 
 **Networks**
 
@@ -22,7 +22,7 @@ This example shows you how to use Terraform to create a a 3-tier application env
 
 1 RDS instance (MySQL 5.7)
 
-1 Floating IP from the Symphony edge network
+1 elastic IP from the Symphony edge network
 
 ## Before you begin
 
@@ -30,7 +30,7 @@ Before you can use this Terraform example, you need to:
 
 * First, do some setup tasks within Symphony.
 
-* Then, create a `terraform.tfvars` file that supplies your environment-specific values for various variables.
+* Then, edit the sample `terraform.tfvars` file to specify your environment-specific values for various variables.
 
 Each task is described below.
 
@@ -39,30 +39,15 @@ Each task is described below.
 
 Before you can use this Terraform example, you need to do the following tasks within the Symphony GUI:
 
-1. Create a **dedicated VPC-enabled project** for use with Terraform:
+1. Make sure you have used Symphony to:
 
-    **Menu** > **Account Management** > **Accounts** > select an account > **Create Project** > select existing Symphony edge network for this project
+    * Create a VPC-enabled project
 
-    For more information about using VPC-enabled projects, see [additional information about using VPC-enabled projects](https://knowledge2.stratoscale.com/display/SYMP/Using+a+VPC-Enabled+Project).
-    
-2. Create a **Tenant Admin user** that is associated the the project you just created:
+    * Obtain access and secret keys for that project
 
-    **Menu** > **Account Management*** > **Accounts** > select an account > **Users** > **Create User**
-    
-    **Projects** field: specify the project you just created
-    
-    **Account Roles** field: specify **Tenant Admin**
-    
-3. Get the **access and secret keys for the project**:
+    For information on how to do these tasks, click [here](../README.md) 
 
-    Log in to the Symhony GUI as the Tenant Admin user you just created.
-    
-    In the upper right corner, click **Hi username** > **Access Keys** > **Create**
-    
-    Copy both the access key and the secret key (click the copy icon to the right of each key).
-    
-
-4. **Upload the image** you will use for your web server(s) into Symphony:
+2. **Upload the image** you will use for your web server(s) into Symphony:
 
     Use the Ubuntu Xenial cloud image at this URL:
     
@@ -73,7 +58,7 @@ Before you can use this Terraform example, you need to do the following tasks wi
     **Menu** > **Applications** > **Images** > **Create** > specify URL
     
     
-5. Get the **AMI ID** for the image you just uploaded into Symphony:
+3. Get the **AMI ID** for the image you just uploaded into Symphony:
 
     **Menu** > **Applications** > **Images**
     
@@ -81,24 +66,56 @@ Before you can use this Terraform example, you need to do the following tasks wi
     
     ami-1b8ecb82893a4d1f9d500ce33d90496c
     
-6. Enable load balancing:
+4. Enable load balancing:
 
     **Menu** > **Region Management** > **Settings** > **Services & Support** > click Load Balancing toggle to ON.
     
-7. Enable and initialize RDS using a MySQL 5.7 engine:
+5. Enable and initialize RDS using a MySQL 5.7 engine:
 
     **Menu** > **Region Management** > **Settings** > **Services & Support** > click Database toggle to ON.
     
     
-### Before you begin: create `terraform.tfvars`
+### Before you begin: edit `terraform.tfvars`
 
-Use the included `terraform.tfvars.sample` file as a template. For each variable, fill in your environment-specific value.
+Use the included `terraform.tfvars` file as a template. For each variable, fill in your environment-specific value, as described below:
 
-Save the sample file as `terraform.tfvars` (remove the `.sample` extension) before running `terraform apply`.
+**Basic variables**
+
+The following variables: `symphony_ip`, `symp_access_key`, `symp_secret_key` are described [here](../ec2-instance/README.md).
+
+
+**web_number**
+
+Number of web servers (load balancer will automatically manage target groups).
+
+**web_ami***
+
+The AMI ID for the Xenial image you jsut uploaded into Symphony. It has a format like this:
+    
+ami-1b8ecb82893a4d1f9d500ce33d90496c
+
+**web_instance_type**
+
+The instance type you want to use for your web server(s). Example: t2.medium
+
+**public_keypair_path**
+
+The path to the public key file that Terraform will pass to Symhpony for authentication.
+
+Background: You can generate a kepair using a tool such as `ssh-keygen`. Place the public and private keys on the machine on which you are running Terraform, for example:
+
+/path/to/myKey.pub
+
+/path/to/myKey.pem
+
+In this example, you would set the `public_keypair_path` to `/path/to/myKey.pub`.
+
 
 ## How to use
 
 1. Get the most recent version of Terraform.
+
+2. Run `terraform init`.
 
 2. Run `terraform apply`
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -142,25 +142,56 @@ Database name.
 
 2. Run `terraform init`.
 
-3. Run `terraform apply`. Take a look at the `terraform apply`output and note that it includes the elastic IP of the load balancer. Make a note of this load balancer IP, because you will need it later to access Wordpress.
+3. Run `terraform apply`. Take a look at the `terraform apply`output and note that it includes the elastic IP (EIP) of the load balancer. Make a note of this load balancer EIP, because you will need it later to access Wordpress.
 
 4. Point your browser to Wordpress at this location:
 
-    `http://<wordpress_ip>:80`
+    `http://<load_balancer_eip>:80`
 
     Initially, you will see the Wordpress installation and configuration pages.
 
-    How to get the _<wordpress_ip>_:
-
-    The Wordpress IP that you want here is the elastiic IP (EIP) of the load balancer:
+    **How to get the _<load_balancer_eip>_**:
 
     * This load balancer EIP was part of the output from `terraform apply`. You can always redisplay that output by running `terraform refresh`.
 
     * You can also get the load balancer EIP from the Symphony GUI:
 
-    **Menu** > **Load Balancing** > **Load Balancers** > select the load that Terraform just created
+        **Menu** > **Load Balancing** > **Load Balancers** > select the load balancer that Terraform just created.
 
-    The field marked **Floating IP** contains the load balancer EIP that you need to access Wordpress.
+        The field marked **Floating IP** contains the load balancer EIP that you need to access Wordpress.
+        
+### SSH access to web servers
+
+There may be times when you want to SSH into the web servers that are part of your Wordpress deployment. This can be for troubleshooting or other purposes:
+
+**To SSH into a web server**
+
+Here is a sample scenario:
+
+1. Make sure you know the path to where you stored your private key file on the machine where you are running Terraform, for example:
+
+    `/path/to/myKey.pem`
+
+2. Get the elastic IP (EIP) of the web server instance -- use either `terraform refresh` or the GUI:
+
+    **Menu** > **Compute** > **Intances** > instance name > **Networks** field -- see IP next to that
+    
+3. In the `terraform.tfvars` file, set `connect_instances_to_web_ip` to `True`. This enables SSH access into web instances.
+
+4. Run `terraform  apply`.
+
+5. SSH into the web server using syntax like this:
+
+    `ssh -i '/path/to/myKey.pem' ubuntu@<eip_of_web_server_instance>`
+   
+When you no longer need SSH access into the web server, you can reset it like this:
+
+Change `connect_instances_to_wepb_ip` back to `False`.
+
+Run `terraform apply` again.
+
+
+
 
 
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -86,6 +86,8 @@ Before you can use this Terraform example, you need to do the following tasks wi
 
 Use the included `terraform.tfvars.sample` file as a template. For each variable, fill in your environment-specific value.
 
+Save the sample file as `terraform.tfvars` (remove the `.sample` extension) before running `terraform apply`.
+
 
 
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -64,9 +64,9 @@ Before you can use this Terraform example, you need to do the following tasks wi
 
 4. **Upload the image** you will use for your web server(s) into Symphony:
 
-    Use an Ubuntu Xenial cloud image.
+    Use the Ubuntu Xenial cloud image at this URL:
     
-    Handy URL - https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+    https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
     
     To upload the image into Symphony:
     

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -88,7 +88,7 @@ The following variables: `symphony_ip`, `symp_access_key`, `symp_secret_key` are
 
 Number of web servers (load balancer will automatically manage target groups).
 
-**web_ami***
+**web_ami**
 
 The AMI ID for the Xenial image you jsut uploaded into Symphony. It has a format like this:
     

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -2,7 +2,7 @@
 
 This example shows you how to use Terraform to create a a 3-tier application environment for Wordpress.
 
-## What this example installs:
+## What this example installs
 
 **Networks**
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -43,7 +43,7 @@ Before you can use this Terraform example, you need to do the following tasks wi
 
     **Menu** > **Account Management** > **Accounts** > select an account > **Create Project** > select existing Symphony edge network for this project
 
-    For more information about using VPC-enabled projects, see link-to-public-doc.
+    For more information about using VPC-enabled projects, see [additional information about using VPC-enabled projects](https://www.stratoscale.com/docs/Using-a-VPC-Enabled-Project/).
     
 2. Create a **Tenant Admin user** that is associated the the project you just created:
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -43,7 +43,7 @@ Before you can use this Terraform example, you need to do the following tasks wi
 
     **Menu** > **Account Management** > **Accounts** > select an account > **Create Project** > select existing Symphony edge network for this project
 
-    For more information about using VPC-enabled projects, see [additional information about using VPC-enabled projects](https://www.stratoscale.com/docs/Using-a-VPC-Enabled-Project/).
+    For more information about using VPC-enabled projects, see [additional information about using VPC-enabled projects](https://www.stratoscale.com/docs/using-a-vpc-enabled-project/?preview_id=26391&preview_nonce=aff515ec73&preview=true).
     
 2. Create a **Tenant Admin user** that is associated the the project you just created:
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -14,7 +14,7 @@ This example shows you how to use Terraform to create a a 3-tier application env
 
 1 Public subnet
 
-Other resources: 
+**Other resources**
 
 1 load balancer
 
@@ -83,6 +83,8 @@ Before you can use this Terraform example, you need to do the following tasks wi
     
     
 ### Create `terraform.tfvars`
+
+Use the included `terraform.tfvars.sample` file as a template. For each variable, fill in your environment-specific value.
 
 
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -81,13 +81,13 @@ Before you can use this Terraform example, you need to do the following tasks wi
     
     ami-1b8ecb82893a4d1f9d500ce33d90496c
     
-6. Enable and initialize load balancing:
+6. Enable load balancing:
 
-    **Menu** > ... to be continued
+    **Menu** > **Region Management** > **Settings** > **Services & Support** > click Load Balancing toggle to ON.
     
 7. Enable and initialize RDS using a MySQL 5.7 engine:
 
-    **Menu** > ... to be continued
+    **Menu** > **Region Management** > **Settings** > **Services & Support** > click Database toggle to ON.
     
     
 ### Before you begin: create `terraform.tfvars`

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -47,7 +47,7 @@ Before you can use this Terraform example, you need to do the following tasks wi
     
 2. Create a **Tenant Admin user** that is associated the the project you just created:
 
-    **Menu** > **Account Management*** > **Accounts** > select an account > "Users" > "Create User"
+    **Menu** > **Account Management*** > **Accounts** > select an account > **Users** > "Create User"
     
     **Projects** field: specify the project you just created
     

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -51,7 +51,7 @@ Before you can use this Terraform example, you need to do the following tasks wi
     
     **Projects** field: specify the project you just created
     
-    **Account Roles** field: specify **Tenant Admin***
+    **Account Roles** field: specify **Tenant Admin**
     
 3. Get the **access and secret keys for the project**:
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -74,6 +74,8 @@ Before you can use this Terraform example, you need to do the following tasks wi
 
     **Menu** > **Region Management** > **Settings** > **Services & Support** > click Database toggle to ON.
     
+    **Menu** > **Database** > **Engines** > MySQL 5.7.00 > toggle **Enabled** switch to ON.
+    
     
 ### Before you begin: edit `terraform.tfvars`
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -96,7 +96,11 @@ Use the included `terraform.tfvars.sample` file as a template. For each variable
 
 Save the sample file as `terraform.tfvars` (remove the `.sample` extension) before running `terraform apply`.
 
+## How to use
 
+1. Get the most recent version of Terraform.
+
+2. Run `terraform apply`
 
 
     

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -47,7 +47,7 @@ Before you can use this Terraform example, you need to do the following tasks wi
     
 2. Create a **Tenant Admin user** that is associated the the project you just created:
 
-    **Menu** > **Account Management*** > **Accounts** > select an account > **Users** > "Create User"
+    **Menu** > **Account Management*** > **Accounts** > select an account > **Users** > **Create User**
     
     **Projects** field: specify the project you just created
     
@@ -57,7 +57,7 @@ Before you can use this Terraform example, you need to do the following tasks wi
 
     Log in to the Symhony GUI as the Tenant Admin user you just created.
     
-    In the upper right corner, click "Hi username" > "Access Keys" > "Create"
+    In the upper right corner, click **Hi username** > **Access Keys** > **Create**
     
     Copy both the access key and the secret key (click the copy icon to the right of each key).
     

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -4,18 +4,24 @@ This example shows you how to use Terraform to create a a 3-tier application env
 
 ## What this example installs:
 
-Networks:
+**Networks**
 
 1 VPC
-1 Database subnets
-1 Web subnets
+
+1 Database subnet
+
+1 Web subnet
+
 1 Public subnet
 
 Other resources: 
 
-1 Netwrok Load Balancer
+1 load balancer
+
 1 or more web servers (Ubuntu Xenial)
+
 1 RDS instance (MySQL 5.7)
+
 1 Floating IP from the Symphony edge network
 
 ## Before You Begin
@@ -24,7 +30,7 @@ Before you can use this Terraform example, you need to:
 
 * First, do some setup tasks within Symphony.
 
-* Then, create a terraform.tfvars file that supplies your environment-specific values for various variables.
+* Then, create a `terraform.tfvars` file that supplies your environment-specific values for various variables.
 
 Each task is described below.
 
@@ -37,7 +43,7 @@ Before you can use this Terraform example, you need to do the following tasks wi
 
     **Menu** > **Account Management** > **Accounts** > select an account > **Create Project** > select existing Symphony edge network for this project
 
-    For more information about using VPC-enabled projects, see <link-to-public-doc>
+    For more information about using VPC-enabled projects, see link-to-public-doc.
     
 2. Create a **Tenant Admin user** that is associated the the project you just created:
 
@@ -77,6 +83,8 @@ Before you can use this Terraform example, you need to do the following tasks wi
     
     
 ### Create `terraform.tfvars`
+
+
 
 
     

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -24,7 +24,7 @@ This example shows you how to use Terraform to create a a 3-tier application env
 
 1 Floating IP from the Symphony edge network
 
-## Before You Begin
+## Before you begin
 
 Before you can use this Terraform example, you need to:
 
@@ -35,7 +35,7 @@ Before you can use this Terraform example, you need to:
 Each task is described below.
 
 
-### Symphony setup tasks
+### Before you begin: Symphony setup tasks
 
 Before you can use this Terraform example, you need to do the following tasks within the Symphony GUI:
 
@@ -82,7 +82,7 @@ Before you can use this Terraform example, you need to do the following tasks wi
     ami-1b8ecb82893a4d1f9d500ce33d90496c
     
     
-### Create `terraform.tfvars`
+### Before you begin: create `terraform.tfvars`
 
 Use the included `terraform.tfvars.sample` file as a template. For each variable, fill in your environment-specific value.
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -18,7 +18,7 @@ This example shows you how to use Terraform to create a a 3-tier application env
 
 1 load balancer
 
-1 or more web servers (Ubuntu Xenial)
+2 or more web servers (Ubuntu Xenial)
 
 1 RDS instance (MySQL 5.7)
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -81,6 +81,14 @@ Before you can use this Terraform example, you need to do the following tasks wi
     
     ami-1b8ecb82893a4d1f9d500ce33d90496c
     
+6. Enable and initialize load balancing:
+
+    **Menu** > ... to be continued
+    
+7. Enable and initialize RDS using a MySQL 5.7 engine:
+
+    **Menu** > ... to be continued
+    
     
 ### Before you begin: create `terraform.tfvars`
 

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -107,11 +107,11 @@ The path to the public key file that Terraform will pass to Symhpony for authent
 
 Background: You can generate a kepair using a tool such as `ssh-keygen`. Place the public and private keys on the machine on which you are running Terraform, for example:
 
-/path/to/myKey.pub
+Assume you put the public key file here: `/path/to/myKey.pub`
 
-/path/to/myKey.pem
+And you put the private key file here: `/path/to/myKey.pem`
 
-In this example, you would set the `public_keypair_path` to `/pa**th/to/myKey.pub`.
+In this example, you would set the `public_keypair_path` variable to `/path/to/myKey.pub`.
 
 **connect_instances_to_web_ip**
 
@@ -142,7 +142,27 @@ Database name.
 
 2. Run `terraform init`.
 
-2. Run `terraform apply`.
+3. Run `terraform apply`. Take a look at the `terraform apply`output and note that it includes the elastic IP of the load balancer. Make a note of this load balancer IP, because you will need it later to access Wordpress.
+
+4. Point your browser to Wordpress at this location:
+
+`http://<wordpress_ip>:80`
+
+Initially, you will see the Wordpress installation and configuration pages.
+
+How to get the _<wordpress_ip>_:
+
+The Wordpress IP that you want here is the elastiic IP (EIP) of the load balancer:
+
+* This load balancer EIP was part of the output from `terraform apply`. You can always redisplay that output by running `terraform refresh`.
+
+* You can also get the load balancer EIP from the Symphony GUI:
+
+**Menu** > **Load Balancing** > **Load Balancers** > select the load that Terraform just created
+
+The field marked **Floating IP** contains the load balancer EIP that you need to access Wordpress.
+
+
 
 
     

--- a/terraform/wordpress-3tier-app/readme.md
+++ b/terraform/wordpress-3tier-app/readme.md
@@ -81,10 +81,11 @@ Before you can use this Terraform example, you need to do the following tasks wi
 
 Use the included `terraform.tfvars` file as a template. For each variable, fill in your environment-specific value, as described below:
 
-**Basic variables**
+_Basic variables_
 
-The following variables: `symphony_ip`, `symp_access_key`, `symp_secret_key` are described [here](../ec2-instance/README.md).
+The following variables: **symphony_ip**, **symp_access_key**, **symp_secret_key** are described [here](../ec2-instance/README.md).
 
+_Web server variables_
 
 **web_number**
 
@@ -110,7 +111,29 @@ Background: You can generate a kepair using a tool such as `ssh-keygen`. Place t
 
 /path/to/myKey.pem
 
-In this example, you would set the `public_keypair_path` to `/path/to/myKey.pub`.
+In this example, you would set the `public_keypair_path` to `/pa**th/to/myKey.pub`.
+
+**connect_instances_to_web_ip**
+
+Boolean. Controls whether or not you can SSH into the web server instances:
+
+`False`(default) isolates the web servers from SSH access into them.
+
+`True` lets you SSH into the web server instances for troubleshooting or other purposes. For more information, see the _SSH access_ info in the **How to use** section below. 
+
+_Database variables. Note that the Wordpress container uses the Wordpress database by default_
+
+**db_password**
+
+Database password.
+
+**db_user**
+
+Database user.
+
+**db_name**
+
+Database name.
 
 
 ## How to use
@@ -119,7 +142,7 @@ In this example, you would set the `public_keypair_path` to `/path/to/myKey.pub`
 
 2. Run `terraform init`.
 
-2. Run `terraform apply`
+2. Run `terraform apply`.
 
 
     

--- a/terraform/wordpress-3tier-app/terraform.tfvars.sample
+++ b/terraform/wordpress-3tier-app/terraform.tfvars.sample
@@ -1,0 +1,38 @@
+# Sample tfvars file 
+# omit .sample from extension before applying 
+
+# Stratoscale Symphony credentials
+
+symp_access_key = ""
+symp_secret_key = ""
+symphony_ip = ""
+
+
+# Number of web servers (load balancer will automatically manage target groups)
+
+web_number = "2"
+
+#Use an Ubuntu Xenial cloud image
+#Handy URL - https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+
+web_ami = ""
+web_instance_type = "t2.medium"
+
+# Public keypair path
+
+public_keypair_path = ""
+
+
+
+#Database information (Wordpress container will use wordpress database by default)
+
+db_user = "admin"
+db_password = "stratoscale"
+db_name = ""
+
+# Connect instances to web IPs
+
+connect_instances_to_web_ips = ""
+
+
+

--- a/terraform/wordpress-3tier-app/terraform.tfvars.sample
+++ b/terraform/wordpress-3tier-app/terraform.tfvars.sample
@@ -1,38 +1,42 @@
 # Sample tfvars file 
 # omit .sample from extension before applying 
 
+############################
+
 # Stratoscale Symphony credentials
 
-symp_access_key = ""
-symp_secret_key = ""
-symphony_ip = ""
+symp_access_key = "<Access key>"
+symp_secret_key = "<Secret key>"
+symphony_ip = "<Symphony IP>"
 
+############################
+
+# Web servers info
 
 # Number of web servers (load balancer will automatically manage target groups)
 
 web_number = "2"
 
-#Use an Ubuntu Xenial cloud image
-#Handy URL - https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+# Image to use for web servers -- use an Ubuntu Xenial cloud image
+# We recommend that you use this one: 
+# https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
 
-web_ami = ""
-web_instance_type = "t2.medium"
+web_ami = "<AMI image ID>"
 
-# Public keypair path
+web_instance_type = "t2.small"
 
-public_keypair_path = ""
+connect_instances_to_web_ips = false
 
+public_keypair_path = "<Path to public keypair>"
 
+############################
 
-#Database information (Wordpress container will use wordpress database by default)
+# Database information
+# (Wordpress container will use wordpress database by default)
 
 db_user = "admin"
-db_password = "stratoscale"
-db_name = ""
+db_password = "adminpassworddb"
+db_name = "wordpress"
 
-# Connect instances to web IPs
-
-connect_instances_to_web_ips = ""
-
-
+############################
 


### PR DESCRIPTION
All I care about here are the readme edits - I think they belong in the public master.

As we discussed, we can get rid of the terraform.tfvars.sample file.