### PR TITLE
Fix AWS providers ec2-instance and ec2-vpc-multi-instances:

### DIFF
--- a/terraform/ec2-instance/aws-provider.tf
+++ b/terraform/ec2-instance/aws-provider.tf
@@ -11,9 +11,11 @@ provider "aws" {
   insecure = "true"
   skip_metadata_api_check = true
   skip_credentials_validation = true
+  skip_requesting_account_id = true
+
+  # Pinning AWS plugin version
+  version = "=1.31.0"
 
   # No importance for this value currently
-    region = "us-east-2"
-  # Version is pinned to 1.28 for now 
-    version = "1.28"
+  region = "us-east-1"
 }

--- a/terraform/ec2-vpc-multi-instances/aws-provider.tf
+++ b/terraform/ec2-vpc-multi-instances/aws-provider.tf
@@ -1,15 +1,19 @@
 provider "aws" {
-    access_key = "${var.access_key}"
-    secret_key = "${var.secret_key}"
+  access_key = "${var.access_key}"
+  secret_key = "${var.secret_key}"
 
-    endpoints {
-       ec2 = "https://${var.symphony_ip}/api/v2/aws/ec2"
-    }
+  endpoints {
+     ec2 = "https://${var.symphony_ip}/api/v2/aws/ec2"
+  }
 
-    insecure = "true"
-    skip_metadata_api_check = true
-    skip_credentials_validation = true
+  insecure = "true"
+  skip_metadata_api_check = true
+  skip_credentials_validation = true
+  skip_requesting_account_id = true
 
-    # No importance for this value currently
-    region = "us-east-1"
+  # Pinning AWS plugin version
+  version = "=1.31.0"
+
+  # No importance for this value currently
+  region = "us-east-1"
 }


### PR DESCRIPTION
1. Pin plugin to 1.31.0
2. Add skip_account_id validation. Must for 1.31
3. Fix inden