### PR TITLE
Create Packer readme.md

### DIFF
--- a/terraform/packer/readme.md
+++ b/terraform/packer/readme.md
@@ -1,0 +1,121 @@
+# Packer Example
+
+This example shows you how to use Terraform and Packer to create an Ubuntu AMI with Docker installed. The AMI is stored within Symphony, where users can easily access and deploy it.
+
+## High level overview
+
+At a high level, this example performs the following steps:
+
+* Terraform creates a Bastion jump server and supporting network environment.
+
+* Packer creates and boots a temporary Packer instance, then SSHs into the temporary instance through the Bastion server.
+
+* Once inside the temporary instance, Packer runs the provisioner commands to install Docker, clones the Docker-provisioned instance into an output AMI, and uploads the output AMI into Symphony.
+
+* Finally, Packer kills the temporary instance and exits.
+
+## Before you begin
+
+Before you can use this Terraform example, you need to:
+
+* First, do some setup tasks within Symphony.
+
+* Then, edit the sample `terraform.tfvars` file to specify your environment-specific values for various variables.
+
+Each task is described below.
+
+
+### Before you begin: Symphony setup tasks
+
+Before you can use this Terraform example, you need to do the following tasks within the Symphony GUI:
+
+1. Make sure you have used Symphony to:
+
+    * Create a **VPC-enabled project**
+
+    * Obtain **access and secret keys** for that project
+
+   For information on how to do these tasks, click [here](../README.md). 
+
+2. **Upload the image (or images)** you will use for both the Bastion and Packer instances into Symphony:
+
+    This example uses this same Ubuntu Xenial cloud image for both Bastion and Packer instances:
+    
+    https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+    
+    To upload the image into Symphony:
+    
+    **Menu** > **Applications** > **Images** > **Create** > specify URL
+    
+    After you upload the image, set its Scope to Public:
+    
+    **Menu** > **Applications** > **Images** > Select the image > **Modify** > set the **Scope** field to Public
+    
+    
+3. Get the **AMI ID** for the image you just uploaded into Symphony:
+
+    **Menu** > **Applications** > **Images**
+    
+    Click the name of the image you just uploaded and copy the AWS ID value -- it has a format like this:
+    
+    ami-1b8ecb82893a4d1f9d500ce33d90496c
+    
+### Before you begin: edit `terraform.tfvars`
+
+Use the included `terraform.tfvars` file as a template. For each variable, fill in your environment-specific value, as described below:
+
+_BASIC VARIABLES_
+
+The following variables: **symphony_ip**, **access_key**, **secret_key** are described [here](../ec2-instance/README.md).
+
+_AMI VARIABLES_
+
+**bastion_ami_image**
+
+The ID of the image you want Terraform to use to create the Bastion jump server.
+
+**bastion_user_name**
+
+The username that Packer will use to SSH into the Bastion jump server.
+
+**packer_ami_image**
+
+The ID of the image you want Packer to use to create the Packer temporary instance.
+
+**packer_user_name**
+
+The username that Packer will use to SSH from Bastion into the Packer temporary instance.
+
+_KEYPAIR VARIABLES_
+
+Note: This example uses the same key pair for both Bastion and Packer instances.
+
+**public_keypair_path**
+
+Full path to the public key file that Packer will create the temporary instance with.
+
+**private_keypair_path**
+
+Full path to the private key file that Packer will use to SSH into the temporary instance.
+
+## How to use
+
+1. Install the most recent version of Packer.
+
+2. Install the most recent version of Terraform.
+
+3. Run `terraform init`.
+
+4. Run `terraform apply`.
+
+5. Run `packer build packer_generated.json`. This command creates the Docker-provisioned output AMI and uploads it into Symphony.
+
+    Notes:
+    
+    * This example automatically creates the `packer_generated.json` file, based on the template contained in `packer_gen.template`.
+    
+    * For the `packer build` command to succeed, your Symphony region must have a valid certificate.
+    
+6. Verify that the output AMI is available in Symphony:
+
+    **Menu** > **Applications** > **Images** > image name will be `packer-example {{timestamp}}`.


### PR DESCRIPTION
This readme describes how to use the Packer example to automatically create a Docker-provisioned AMI.

Topics include:

* High level process overview

* Required preliminary tasks

* Descriptions of `terraform.tfvars` values

* How to run the scripts

* How to verify that the AMI was successfully created and uploaded into Symphony